### PR TITLE
Add MudBlazor UI and Excel search service

### DIFF
--- a/reestr/Components/App.razor
+++ b/reestr/Components/App.razor
@@ -8,12 +8,14 @@
     <link rel="stylesheet" href="bootstrap/bootstrap.min.css" />
     <link rel="stylesheet" href="app.css" />
     <link rel="stylesheet" href="reestr.styles.css" />
+    <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <link rel="icon" type="image/png" href="favicon.png" />
     <HeadOutlet />
 </head>
 
 <body>
     <Routes />
+    <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="_framework/blazor.web.js"></script>
 </body>
 

--- a/reestr/Components/Layout/MainLayout.razor
+++ b/reestr/Components/Layout/MainLayout.razor
@@ -1,23 +1,18 @@
-﻿@inherits LayoutComponentBase
+@inherits LayoutComponentBase
 
-<div class="page">
-    <div class="sidebar">
-        <NavMenu />
-    </div>
-
-    <main>
-        <div class="top-row px-4">
-            <a href="https://learn.microsoft.com/aspnet/core/" target="_blank">About</a>
-        </div>
-
-        <article class="content px-4">
-            @Body
-        </article>
-    </main>
-</div>
-
-<div id="blazor-error-ui">
-    An unhandled error has occurred.
-    <a href="" class="reload">Reload</a>
-    <a class="dismiss">🗙</a>
-</div>
+<MudThemeProvider>
+    <MudDialogProvider />
+    <MudSnackbarProvider>
+        <MudLayout>
+            <MudAppBar Color="Color.Primary">
+                <MudText Typo="Typo.h6">Reestr</MudText>
+            </MudAppBar>
+            <MudDrawer Open="true" Variant="DrawerVariant.Mini" Elevation="1">
+                <NavMenu />
+            </MudDrawer>
+            <MudMainContent Class="p-4">
+                @Body
+            </MudMainContent>
+        </MudLayout>
+    </MudSnackbarProvider>
+</MudThemeProvider>

--- a/reestr/Components/Layout/NavMenu.razor
+++ b/reestr/Components/Layout/NavMenu.razor
@@ -1,30 +1,4 @@
-﻿<div class="top-row ps-3 navbar navbar-dark">
-    <div class="container-fluid">
-        <a class="navbar-brand" href="">reestr</a>
-    </div>
-</div>
-
-<input type="checkbox" title="Navigation menu" class="navbar-toggler" />
-
-<div class="nav-scrollable" onclick="document.querySelector('.navbar-toggler').click()">
-    <nav class="flex-column">
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
-                <span class="bi bi-house-door-fill-nav-menu" aria-hidden="true"></span> Home
-            </NavLink>
-        </div>
-
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="counter">
-                <span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> Counter
-            </NavLink>
-        </div>
-
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="weather">
-                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Weather
-            </NavLink>
-        </div>
-    </nav>
-</div>
-
+<MudNavMenu>
+    <MudNavLink Href="" Icon="@Icons.Material.Filled.Info" Match="NavLinkMatch.All">Общая информация</MudNavLink>
+    <MudNavLink Href="search" Icon="@Icons.Material.Filled.Search">Поиск информации</MudNavLink>
+</MudNavMenu>

--- a/reestr/Components/Pages/ChooseDateDialog.razor
+++ b/reestr/Components/Pages/ChooseDateDialog.razor
@@ -1,0 +1,20 @@
+@using reestr.Services
+@inject MudDialogInstance MudDialog
+@code {
+    [Parameter] public List<ReestrEntry> Entries { get; set; } = new();
+    private void Select(ReestrEntry entry) => MudDialog.Close(DialogResult.Ok(entry));
+}
+
+<MudDialog>
+    <MudDialogTitle>Выберите дату</MudDialogTitle>
+    <MudDialogContent>
+        <MudList T="ReestrEntry">
+            @foreach (var item in Entries)
+            {
+                <MudListItem Style="cursor:pointer" @onclick="() => Select(item)">
+                    @item.OrderWithDate
+                </MudListItem>
+            }
+        </MudList>
+    </MudDialogContent>
+</MudDialog>

--- a/reestr/Components/Pages/Home.razor
+++ b/reestr/Components/Pages/Home.razor
@@ -1,7 +1,14 @@
-﻿@page "/"
+@page "/"
 
-<PageTitle>Home</PageTitle>
+<PageTitle>Общая информация</PageTitle>
 
-<h1>Hello, world!</h1>
-
-Welcome to your new app.
+<MudCard Class="mx-auto my-4" Style="max-width:600px;">
+    <MudCardContent>
+        <MudText Typo="Typo.h5" Class="mb-2">Добро пожаловать!</MudText>
+        <MudText>Это приложение позволяет искать информацию по распоряжениям.</MudText>
+        <MudText>Файл Excel необходимо загрузить через
+            <MudLink Href="https://t.me/examplebot" Target="_blank">Telegram-бота</MudLink>.
+        </MudText>
+        <MudText Class="mt-2">После загрузки файла вы сможете найти номер очереди по номеру распоряжения и МФЦ.</MudText>
+    </MudCardContent>
+</MudCard>

--- a/reestr/Components/Pages/Search.razor
+++ b/reestr/Components/Pages/Search.razor
@@ -1,0 +1,57 @@
+@page "/search"
+@using reestr.Services
+@inject ExcelDataService ExcelService
+@inject IDialogService DialogService
+
+<PageTitle>Поиск информации</PageTitle>
+
+<MudCard Class="mx-auto my-4" Style="max-width:600px;">
+    <MudCardContent>
+        <MudText Typo="Typo.h5" Class="mb-2">Поиск информации</MudText>
+        <MudTextField @bind-Value="OrderNumber" Label="Номер распоряжения" Variant="Variant.Outlined" Class="mb-2" />
+        <MudTextField @bind-Value="MfcNumber" Label="Номер МФЦ" Variant="Variant.Outlined" Class="mb-2" />
+        <MudButton OnClick="PerformSearch" Color="Color.Primary" Variant="Variant.Filled">Найти</MudButton>
+        @if (!string.IsNullOrEmpty(Result))
+        {
+            <MudText Class="mt-2">Результат: @Result</MudText>
+        }
+    </MudCardContent>
+</MudCard>
+
+@code {
+    private string? OrderNumber;
+    private string? MfcNumber;
+    private string? Result;
+
+    private async Task PerformSearch()
+    {
+        Result = string.Empty;
+        if (string.IsNullOrWhiteSpace(OrderNumber))
+            return;
+
+        if (string.IsNullOrWhiteSpace(MfcNumber))
+        {
+            var matches = ExcelService.FindByOrder(OrderNumber).ToList();
+            if (matches.Count == 1)
+            {
+                Result = matches[0].QueueNumber;
+            }
+            else if (matches.Count > 1)
+            {
+                var parameters = new DialogParameters { ["Entries"] = matches };
+                var dialog = DialogService.Show<ChooseDateDialog>("Выберите дату", parameters);
+                var res = await dialog.Result;
+                if (!res.Canceled && res.Data is ReestrEntry entry)
+                {
+                    Result = entry.QueueNumber;
+                }
+            }
+        }
+        else
+        {
+            var match = ExcelService.FindByOrderAndMfc(OrderNumber, MfcNumber);
+            if (match != null)
+                Result = match.QueueNumber;
+        }
+    }
+}

--- a/reestr/Components/_Imports.razor
+++ b/reestr/Components/_Imports.razor
@@ -8,3 +8,4 @@
 @using Microsoft.JSInterop
 @using reestr
 @using reestr.Components
+@using MudBlazor

--- a/reestr/Program.cs
+++ b/reestr/Program.cs
@@ -1,10 +1,31 @@
 using reestr.Components;
+using MudBlazor.Services;
+using reestr.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
+builder.Services.AddMudServices();
+builder.Services.AddSingleton<ExcelDataService>(sp =>
+{
+    var env = sp.GetRequiredService<IWebHostEnvironment>();
+    var service = new ExcelDataService();
+    var file = Path.Combine(env.WebRootPath, "data.xlsx");
+    if (File.Exists(file))
+    {
+        try
+        {
+            service.LoadFromFile(file);
+        }
+        catch (Exception ex)
+        {
+            sp.GetRequiredService<ILogger<Program>>().LogWarning(ex, "Failed to load Excel data");
+        }
+    }
+    return service;
+});
 
 var app = builder.Build();
 

--- a/reestr/Services/ExcelDataService.cs
+++ b/reestr/Services/ExcelDataService.cs
@@ -1,0 +1,44 @@
+using ClosedXML.Excel;
+using System.Text.RegularExpressions;
+
+namespace reestr.Services;
+
+public record ReestrEntry(string QueueNumber, string MfcNumber, string OrderWithDate);
+
+public class ExcelDataService
+{
+    private readonly List<ReestrEntry> _entries = new();
+    public IReadOnlyList<ReestrEntry> Entries => _entries;
+
+    public void LoadFromFile(string path)
+    {
+        using var wb = new XLWorkbook(path);
+        var ws = wb.Worksheets.First();
+        foreach (var row in ws.RowsUsed().Skip(1))
+        {
+            var queue = row.Cell(1).GetString();
+            var mfc = row.Cell(2).GetString();
+            var order = row.Cell(3).GetString();
+            if (ContainsPersonalData(queue) || ContainsPersonalData(mfc) || ContainsPersonalData(order))
+                throw new InvalidOperationException("Файл содержит персональные данные");
+            _entries.Add(new ReestrEntry(queue, mfc, order));
+        }
+    }
+
+    private static bool ContainsPersonalData(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+        // Simple heuristics: FIO pattern or long numbers
+        var fioPattern = new Regex(@"^[А-ЯЁ][а-яё]+\s+[А-ЯЁ][а-яё]+(\s+[А-ЯЁ][а-яё]+)?");
+        var passportPattern = new Regex(@"\b\d{10}\b");
+        var snilsPattern = new Regex(@"\b\d{11}\b");
+        return fioPattern.IsMatch(value) || passportPattern.IsMatch(value) || snilsPattern.IsMatch(value);
+    }
+
+    public IEnumerable<ReestrEntry> FindByOrder(string orderNumber)
+        => _entries.Where(e => e.OrderWithDate.Contains(orderNumber, StringComparison.OrdinalIgnoreCase));
+
+    public ReestrEntry? FindByOrderAndMfc(string orderNumber, string mfc)
+        => _entries.FirstOrDefault(e => e.OrderWithDate.Contains(orderNumber, StringComparison.OrdinalIgnoreCase) && e.MfcNumber == mfc);
+}

--- a/reestr/reestr.csproj
+++ b/reestr/reestr.csproj
@@ -6,4 +6,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="ClosedXML" Version="0.105.0" />
+    <PackageReference Include="MudBlazor" Version="7.0.2" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- integrate MudBlazor into the Blazor Server app
- create ExcelDataService to load data with ClosedXML and validate for personal data
- replace layout and navigation with MudBlazor components
- add "Общая информация" page
- add "Поиск информации" page with dialog to select date

## Testing
- `dotnet build reestr.sln`

------
https://chatgpt.com/codex/tasks/task_e_686179eba66c8323a713ffb1b1e26a3c