### PR TITLE
Fix MudThemeProvider usage

### DIFF
--- a/reestr/Components/Layout/MainLayout.razor
+++ b/reestr/Components/Layout/MainLayout.razor
@@ -1,9 +1,9 @@
 @inherits LayoutComponentBase
 
-<MudThemeProvider>
-    <MudDialogProvider />
-    <MudSnackbarProvider>
-        <MudLayout>
+<MudThemeProvider />
+<MudDialogProvider />
+<MudSnackbarProvider>
+    <MudLayout>
             <MudAppBar Color="Color.Primary">
                 <MudText Typo="Typo.h6">Reestr</MudText>
             </MudAppBar>
@@ -13,6 +13,5 @@
             <MudMainContent Class="p-4">
                 @Body
             </MudMainContent>
-        </MudLayout>
-    </MudSnackbarProvider>
-</MudThemeProvider>
+    </MudLayout>
+</MudSnackbarProvider>


### PR DESCRIPTION
## Summary
- install the .NET 8 SDK
- fix `MainLayout.razor` to use `MudThemeProvider` as a standalone component

## Testing
- `dotnet build reestr.sln -c Release`
- `dotnet run --project reestr/reestr.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68617bd0af608323b85c444f1a3c3f0f