### PR TITLE
Fix white page by using correct content root

### DIFF
--- a/reestr/Program.cs
+++ b/reestr/Program.cs
@@ -2,7 +2,11 @@ using reestr.Components;
 using MudBlazor.Services;
 using reestr.Services;
 
-var builder = WebApplication.CreateBuilder(args);
+var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+{
+    ContentRootPath = AppContext.BaseDirectory,
+    Args = args
+});
 
 // Add services to the container.
 builder.Services.AddRazorComponents()


### PR DESCRIPTION
## Summary
- ensure the app uses the executable directory as ContentRoot
- this allows static files to load correctly even when the app is launched from outside the publish folder

## Testing
- `dotnet build reestr.sln -c Release`
- `dotnet publish reestr/reestr.csproj -c Release -o pub`
- `./pub/reestr --urls http://localhost:5052`

------
https://chatgpt.com/codex/tasks/task_e_68617de1dea48323ac80626d3764f2cf